### PR TITLE
Add a couple other Go RPC frameworks

### DIFF
--- a/gorpc.go
+++ b/gorpc.go
@@ -1,0 +1,73 @@
+package main
+
+import (
+	"crypto/rand"
+	"log"
+	"time"
+
+	"github.com/gogo/protobuf/proto"
+	"github.com/valyala/gorpc"
+)
+
+func doGorpcServer(port string) {
+	payload := make([]byte, *serverPayload)
+	_, _ = rand.Read(payload)
+	s := gorpc.Server{
+		Addr: port,
+		Handler: func(clientAddr string, request interface{}) interface{} {
+			var pingReq PingRequest
+			if err := proto.Unmarshal(request.([]byte), &pingReq); err != nil {
+				log.Fatal(err)
+			}
+			d, err := proto.Marshal(&PingResponse{Payload: payload})
+			if err != nil {
+				log.Fatal(err)
+			}
+			return d
+		},
+	}
+	if err := s.Serve(); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
+}
+
+func gorpcWorker(c *gorpc.Client) {
+	payload := make([]byte, *clientPayload)
+	_, _ = rand.Read(payload)
+
+	for {
+		start := time.Now()
+		d, err := proto.Marshal(&PingRequest{Payload: payload})
+		if err != nil {
+			log.Fatal(err)
+		}
+		resp, err := c.Call(d)
+		if err != nil {
+			log.Fatal(err)
+		}
+		var pingResp PingResponse
+		if err := proto.Unmarshal(resp.([]byte), &pingResp); err != nil {
+			log.Fatal(err)
+		}
+		elapsed := clampLatency(time.Since(start), minLatency, maxLatency)
+		stats.Lock()
+		if err := stats.latency.Current.RecordValue(elapsed.Nanoseconds()); err != nil {
+			log.Fatal(err)
+		}
+		stats.ops++
+		stats.bytes += uint64(len(payload) + len(pingResp.Payload))
+		stats.Unlock()
+	}
+}
+
+func doGorpcClient(addr string) {
+	clients := make([]*gorpc.Client, *connections)
+	for i := 0; i < len(clients); i++ {
+		clients[i] = &gorpc.Client{Addr: addr}
+		clients[i].Start()
+	}
+
+	for i := 0; i < *concurrency; i++ {
+		go gorpcWorker(clients[i%len(clients)])
+	}
+}

--- a/main.go
+++ b/main.go
@@ -49,6 +49,9 @@ func doServer(port string) {
 	case "grpc":
 		doGrpcServer(port)
 
+	case "gorpc":
+		doGorpcServer(port)
+
 	case "x":
 		doXServer(port)
 
@@ -94,6 +97,9 @@ func doClient() {
 	switch *typ {
 	case "grpc":
 		doGrpcClient(addr)
+
+	case "gorpc":
+		doGorpcClient(addr)
 
 	case "x":
 		doXClient(addr)

--- a/main.go
+++ b/main.go
@@ -52,6 +52,9 @@ func doServer(port string) {
 	case "gorpc":
 		doGorpcServer(port)
 
+	case "rpcx":
+		doRPCXServer(port)
+
 	case "x":
 		doXServer(port)
 
@@ -100,6 +103,9 @@ func doClient() {
 
 	case "gorpc":
 		doGorpcClient(addr)
+
+	case "rpcx":
+		doRPCXClient(addr)
 
 	case "x":
 		doXClient(addr)

--- a/rpcx.go
+++ b/rpcx.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"crypto/rand"
+	"log"
+	"time"
+
+	"github.com/smallnest/rpcx/client"
+	"github.com/smallnest/rpcx/protocol"
+	"github.com/smallnest/rpcx/server"
+	context "golang.org/x/net/context"
+)
+
+const (
+	servicePath   = "Pinger"
+	serviceMethod = "Ping"
+)
+
+type rpcxPinger struct {
+	payload []byte
+}
+
+func newRPCXPinger() *rpcxPinger {
+	payload := make([]byte, *serverPayload)
+	_, _ = rand.Read(payload)
+	return &rpcxPinger{payload: payload}
+}
+
+func (p *rpcxPinger) Ping(_ context.Context, req *PingRequest, resp *PingResponse) error {
+	*resp = PingResponse{Payload: p.payload}
+	return nil
+}
+
+func doRPCXServer(addr string) {
+	server := server.NewServer()
+	if err := server.RegisterName(servicePath, newRPCXPinger(), ""); err != nil {
+		log.Fatalf("failed to register server: %v", err)
+	}
+	if err := server.Serve("tcp", addr); err != nil {
+		log.Fatalf("failed to serve: %v", err)
+	}
+}
+
+func rpcxWorker(discovery client.ServiceDiscovery) {
+	option := client.DefaultOption
+	option.SerializeType = protocol.ProtoBuffer
+	c := client.NewXClient(servicePath, client.Failtry, client.RoundRobin, discovery, option)
+	defer c.Close()
+
+	payload := make([]byte, *clientPayload)
+	_, _ = rand.Read(payload)
+
+	for {
+		start := time.Now()
+		var resp PingResponse
+		if err := c.Call(context.Background(), serviceMethod, &PingRequest{Payload: payload}, &resp); err != nil {
+			log.Fatal(err)
+		}
+		elapsed := clampLatency(time.Since(start), minLatency, maxLatency)
+		stats.Lock()
+		if err := stats.latency.Current.RecordValue(elapsed.Nanoseconds()); err != nil {
+			log.Fatal(err)
+		}
+		stats.ops++
+		stats.bytes += uint64(len(payload) + len(resp.Payload))
+		stats.Unlock()
+	}
+}
+
+func doRPCXClient(addr string) {
+	discoveries := make([]client.ServiceDiscovery, *connections)
+	for i := 0; i < len(discoveries); i++ {
+		discoveries[i] = client.NewPeer2PeerDiscovery("tcp@"+addr, "")
+	}
+
+	for i := 0; i < *concurrency; i++ {
+		go rpcxWorker(discoveries[i%len(discoveries)])
+	}
+}


### PR DESCRIPTION
Just some weekend experiments. See commit messages for details. If you'd prefer I just keep this stuff in my own repo, let me know.

Neither of these would be an easy drop-in replacement into our system, and there are more RPC frameworks out there (as rpcx's benchmarks repo shows), but I wanted to play around with a couple.